### PR TITLE
Fix #21 feat: implement category filtering for status and backlog commands

### DIFF
--- a/tests/test_category_filtering.py
+++ b/tests/test_category_filtering.py
@@ -1,0 +1,608 @@
+"""Tests for category filtering functionality."""
+
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+from tasker import (
+    parse_filter_categories, filter_tasks_by_categories, filter_single_task_by_categories,
+    cmd_status, cmd_backlog
+)
+
+
+class TestParseFilterCategories:
+    """Test the parse_filter_categories function."""
+    
+    def test_empty_filter(self):
+        """Test parsing empty filter string."""
+        is_valid, categories, error = parse_filter_categories("")
+        assert is_valid is True
+        assert categories == []
+        assert error == ""
+    
+    def test_none_filter(self):
+        """Test parsing None filter."""
+        is_valid, categories, error = parse_filter_categories(None)
+        assert is_valid is True
+        assert categories == []
+        assert error == ""
+    
+    def test_single_category(self):
+        """Test parsing single category."""
+        is_valid, categories, error = parse_filter_categories("@work")
+        assert is_valid is True
+        assert categories == ["work"]
+        assert error == ""
+    
+    def test_multiple_categories(self):
+        """Test parsing multiple categories."""
+        is_valid, categories, error = parse_filter_categories("@work,@personal")
+        assert is_valid is True
+        assert categories == ["work", "personal"]
+        assert error == ""
+    
+    def test_categories_with_spaces(self):
+        """Test parsing categories with spaces around commas."""
+        is_valid, categories, error = parse_filter_categories("@work, @personal, @client")
+        assert is_valid is True
+        assert categories == ["work", "personal", "client"]
+        assert error == ""
+    
+    def test_duplicate_categories(self):
+        """Test parsing with duplicate categories."""
+        is_valid, categories, error = parse_filter_categories("@work,@personal,@work")
+        assert is_valid is True
+        assert categories == ["work", "personal"]  # duplicates removed
+        assert error == ""
+    
+    def test_case_normalization(self):
+        """Test that categories are normalized to lowercase."""
+        is_valid, categories, error = parse_filter_categories("@Work,@PERSONAL,@Client")
+        assert is_valid is True
+        assert categories == ["work", "personal", "client"]
+        assert error == ""
+    
+    def test_categories_with_underscores_and_hyphens(self):
+        """Test parsing categories with valid special characters."""
+        is_valid, categories, error = parse_filter_categories("@work_project,@client-alpha")
+        assert is_valid is True
+        assert categories == ["work_project", "client-alpha"]
+        assert error == ""
+    
+    def test_categories_with_numbers(self):
+        """Test parsing categories with numbers."""
+        is_valid, categories, error = parse_filter_categories("@project2024,@team1")
+        assert is_valid is True
+        assert categories == ["project2024", "team1"]
+        assert error == ""
+    
+    def test_missing_at_symbol(self):
+        """Test error when @ symbol is missing."""
+        is_valid, categories, error = parse_filter_categories("work,personal")
+        assert is_valid is False
+        assert categories == []
+        assert "Categories must start with @" in error
+        assert "work" in error
+    
+    def test_mixed_valid_invalid(self):
+        """Test error when mixing valid and invalid categories."""
+        is_valid, categories, error = parse_filter_categories("@work,personal")
+        assert is_valid is False
+        assert categories == []
+        assert "Categories must start with @" in error
+        assert "personal" in error
+    
+    def test_invalid_characters(self):
+        """Test error with invalid characters in category names."""
+        is_valid, categories, error = parse_filter_categories("@work space")
+        assert is_valid is False
+        assert categories == []
+        assert "Invalid category format" in error
+    
+    def test_empty_category_name(self):
+        """Test error with empty category name after @."""
+        is_valid, categories, error = parse_filter_categories("@")
+        assert is_valid is False
+        assert categories == []
+        assert "Invalid category format" in error
+    
+    def test_special_characters_invalid(self):
+        """Test error with special characters in category names."""
+        is_valid, categories, error = parse_filter_categories("@work!")
+        assert is_valid is False
+        assert categories == []
+        assert "Invalid category format" in error
+
+
+class TestFilterTasksByCategories:
+    """Test the filter_tasks_by_categories function."""
+    
+    def setup_method(self):
+        """Set up test data."""
+        self.tasks = [
+            {
+                "task": "Work meeting @work",
+                "categories": ["work"],
+                "tags": [],
+                "ts": "2025-05-30T10:00:00"
+            },
+            {
+                "task": "Personal task @personal", 
+                "categories": ["personal"],
+                "tags": [],
+                "ts": "2025-05-30T11:00:00"
+            },
+            {
+                "task": "Mixed task @work @personal",
+                "categories": ["work", "personal"],
+                "tags": [],
+                "ts": "2025-05-30T12:00:00"
+            },
+            {
+                "task": "Client work @client @work",
+                "categories": ["client", "work"],
+                "tags": ["urgent"],
+                "ts": "2025-05-30T13:00:00"
+            },
+            {
+                "task": "No category task",
+                "categories": [],
+                "tags": [],
+                "ts": "2025-05-30T14:00:00"
+            }
+        ]
+    
+    def test_no_filter_returns_all(self):
+        """Test that empty filter returns all tasks."""
+        result = filter_tasks_by_categories(self.tasks, [])
+        assert len(result) == 5
+        assert result == self.tasks
+    
+    def test_single_category_filter(self):
+        """Test filtering by single category."""
+        result = filter_tasks_by_categories(self.tasks, ["work"])
+        assert len(result) == 3  # 3 tasks have @work
+        
+        # Check that correct tasks are returned
+        task_texts = [t["task"] for t in result]
+        assert "Work meeting @work" in task_texts
+        assert "Mixed task @work @personal" in task_texts
+        assert "Client work @client @work" in task_texts
+    
+    def test_multiple_category_filter(self):
+        """Test filtering by multiple categories (OR logic)."""
+        result = filter_tasks_by_categories(self.tasks, ["work", "personal"])
+        assert len(result) == 4  # Fixed: tasks with @work OR @personal
+        # Should include: Work meeting @work, Personal task @personal, 
+        # Mixed task @work @personal, Client work @client @work
+        
+        # Check that correct tasks are returned
+        task_texts = [t["task"] for t in result]
+        assert "Work meeting @work" in task_texts
+        assert "Personal task @personal" in task_texts
+        assert "Mixed task @work @personal" in task_texts
+        assert "Client work @client @work" in task_texts
+    
+    def test_nonexistent_category(self):
+        """Test filtering by category that doesn't exist."""
+        result = filter_tasks_by_categories(self.tasks, ["nonexistent"])
+        assert len(result) == 0
+    
+    def test_client_category_filter(self):
+        """Test filtering by client category."""
+        result = filter_tasks_by_categories(self.tasks, ["client"])
+        assert len(result) == 1
+        assert result[0]["task"] == "Client work @client @work"
+    
+    def test_case_insensitive_filtering(self):
+        """Test that filtering is case insensitive."""
+        # Add a task with mixed case categories
+        mixed_case_task = {
+            "task": "Mixed case @Work",
+            "categories": ["work"],  # stored normalized
+            "tags": [],
+            "ts": "2025-05-30T15:00:00"
+        }
+        tasks_with_mixed = self.tasks + [mixed_case_task]
+        
+        result = filter_tasks_by_categories(tasks_with_mixed, ["work"])
+        assert len(result) == 4  # should include mixed case task
+    
+    def test_legacy_format_tasks(self):
+        """Test filtering tasks in legacy string format."""
+        legacy_tasks = [
+            {"task": "Legacy work task @work"},
+            {"task": "Legacy personal @personal"},
+            {"task": "Legacy no category"}
+        ]
+        
+        result = filter_tasks_by_categories(legacy_tasks, ["work"])
+        assert len(result) == 1
+        assert result[0]["task"] == "Legacy work task @work"
+    
+    def test_very_old_format_tasks(self):
+        """Test filtering very old format (just strings)."""
+        old_tasks = [
+            "Old work task @work",
+            "Old personal @personal", 
+            "Old no category"
+        ]
+        
+        result = filter_tasks_by_categories(old_tasks, ["work"])
+        assert len(result) == 1
+        assert result[0] == "Old work task @work"
+    
+    def test_mixed_format_tasks(self):
+        """Test filtering with mixed task formats."""
+        mixed_tasks = [
+            {  # New format
+                "task": "New format @work",
+                "categories": ["work"],
+                "tags": [],
+                "ts": "2025-05-30T10:00:00"
+            },
+            {"task": "Legacy format @personal"},  # Legacy format
+            "Very old format @client"  # Very old format
+        ]
+        
+        result = filter_tasks_by_categories(mixed_tasks, ["work"])
+        assert len(result) == 1
+        assert result[0]["task"] == "New format @work"
+        
+        result = filter_tasks_by_categories(mixed_tasks, ["personal"])
+        assert len(result) == 1
+        assert result[0]["task"] == "Legacy format @personal"
+        
+        result = filter_tasks_by_categories(mixed_tasks, ["client"])
+        assert len(result) == 1
+        assert result[0] == "Very old format @client"
+
+
+class TestFilterSingleTaskByCategories:
+    """Test the filter_single_task_by_categories function."""
+    
+    def test_no_filter_returns_true(self):
+        """Test that no filter always returns True."""
+        task = {"task": "Any task", "categories": ["work"]}
+        assert filter_single_task_by_categories(task, []) is True
+    
+    def test_matching_category(self):
+        """Test task matches filter category."""
+        task = {"task": "Work task @work", "categories": ["work"]}
+        assert filter_single_task_by_categories(task, ["work"]) is True
+    
+    def test_non_matching_category(self):
+        """Test task doesn't match filter category."""
+        task = {"task": "Work task @work", "categories": ["work"]}
+        assert filter_single_task_by_categories(task, ["personal"]) is False
+    
+    def test_multiple_categories_task(self):
+        """Test task with multiple categories."""
+        task = {"task": "Mixed @work @personal", "categories": ["work", "personal"]}
+        assert filter_single_task_by_categories(task, ["work"]) is True
+        assert filter_single_task_by_categories(task, ["personal"]) is True
+        assert filter_single_task_by_categories(task, ["client"]) is False
+    
+    def test_multiple_filter_categories(self):
+        """Test filtering with multiple categories (OR logic)."""
+        task = {"task": "Work task @work", "categories": ["work"]}
+        assert filter_single_task_by_categories(task, ["work", "personal"]) is True
+        assert filter_single_task_by_categories(task, ["personal", "client"]) is False
+    
+    def test_legacy_format_task(self):
+        """Test filtering legacy format task."""
+        task = {"task": "Legacy work @work"}
+        assert filter_single_task_by_categories(task, ["work"]) is True
+        assert filter_single_task_by_categories(task, ["personal"]) is False
+    
+    def test_string_format_task(self):
+        """Test filtering string format task."""
+        task = "String work task @work"
+        assert filter_single_task_by_categories(task, ["work"]) is True
+        assert filter_single_task_by_categories(task, ["personal"]) is False
+
+
+class TestStatusCommandFiltering:
+    """Test cmd_status with category filtering."""
+    
+    def test_status_with_filter(self, temp_storage, plain_mode, capsys):
+        """Test status command with category filter."""
+        # Setup test data with mixed categories
+        data = {
+            "2025-05-30": {
+                "todo": {
+                    "task": "Active work task @work",
+                    "categories": ["work"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                },
+                "done": [
+                    {
+                        "id": "abc123",
+                        "task": {
+                            "task": "Completed work @work",
+                            "categories": ["work"],
+                            "tags": [],
+                            "ts": "2025-05-30T10:00:00"
+                        },
+                        "ts": "2025-05-30T11:00:00"
+                    },
+                    {
+                        "id": "def456", 
+                        "task": {
+                            "task": "Completed personal @personal",
+                            "categories": ["personal"],
+                            "tags": [],
+                            "ts": "2025-05-30T09:00:00"
+                        },
+                        "ts": "2025-05-30T10:30:00"
+                    }
+                ]
+            },
+            "backlog": []
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        # Test filtering by work category
+        args = MagicMock()
+        args.filter = "@work"
+        
+        cmd_status(args)
+        
+        captured = capsys.readouterr()
+        assert "(filtered by: @work)" in captured.out
+        assert "Active work task @work" in captured.out
+        assert "Completed work @work" in captured.out
+        assert "Completed personal @personal" not in captured.out
+    
+    def test_status_no_matches(self, temp_storage, plain_mode, capsys):
+        """Test status when no tasks match filter."""
+        data = {
+            "2025-05-30": {
+                "todo": {
+                    "task": "Personal task @personal",
+                    "categories": ["personal"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                },
+                "done": []
+            },
+            "backlog": []
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.filter = "@work"
+        
+        cmd_status(args)
+        
+        captured = capsys.readouterr()
+        assert "No active task matches filter" in captured.out
+        assert "No completed tasks match the filter" in captured.out
+    
+    def test_status_invalid_filter(self, temp_storage, plain_mode, capsys):
+        """Test status with invalid filter."""
+        args = MagicMock()
+        args.filter = "work"  # missing @
+        
+        cmd_status(args)
+        
+        captured = capsys.readouterr()
+        assert "Categories must start with @" in captured.out
+    
+    def test_status_multiple_categories(self, temp_storage, plain_mode, capsys):
+        """Test status with multiple category filter."""
+        data = {
+            "2025-05-30": {
+                "todo": {
+                    "task": "Work task @work",
+                    "categories": ["work"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                },
+                "done": [
+                    {
+                        "id": "abc123",
+                        "task": {
+                            "task": "Personal task @personal",
+                            "categories": ["personal"],
+                            "tags": [],
+                            "ts": "2025-05-30T10:00:00"
+                        },
+                        "ts": "2025-05-30T11:00:00"
+                    }
+                ]
+            },
+            "backlog": []
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.filter = "@work,@personal"
+        
+        cmd_status(args)
+        
+        captured = capsys.readouterr()
+        assert "(filtered by: @work, @personal)" in captured.out
+        assert "Work task @work" in captured.out
+        assert "Personal task @personal" in captured.out
+
+
+class TestBacklogCommandFiltering:
+    """Test cmd_backlog with category filtering."""
+    
+    def test_backlog_list_with_filter(self, temp_storage, plain_mode, capsys):
+        """Test backlog list command with category filter."""
+        data = {
+            "backlog": [
+                {
+                    "task": "Work backlog @work",
+                    "categories": ["work"],
+                    "tags": [],
+                    "ts": "2025-05-30T10:00:00"
+                },
+                {
+                    "task": "Personal backlog @personal",
+                    "categories": ["personal"],
+                    "tags": [],
+                    "ts": "2025-05-30T11:00:00"
+                },
+                {
+                    "task": "Client work @client @work",
+                    "categories": ["client", "work"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                }
+            ],
+            "2025-05-30": {"todo": None, "done": []}
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "@work"
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "Backlog (filtered by: @work):" in captured.out
+        assert "Work backlog @work" in captured.out
+        assert "Client work @client @work" in captured.out
+        assert "Personal backlog @personal" not in captured.out
+    
+    def test_backlog_list_no_matches(self, temp_storage, plain_mode, capsys):
+        """Test backlog list when no items match filter."""
+        data = {
+            "backlog": [
+                {
+                    "task": "Personal task @personal",
+                    "categories": ["personal"],
+                    "tags": [],
+                    "ts": "2025-05-30T10:00:00"
+                }
+            ],
+            "2025-05-30": {"todo": None, "done": []}
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "@work"
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "No backlog items match the filter." in captured.out
+    
+    def test_backlog_list_invalid_filter(self, temp_storage, plain_mode, capsys):
+        """Test backlog list with invalid filter."""
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "work"  # missing @
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "Categories must start with @" in captured.out
+    
+    def test_backlog_list_multiple_categories(self, temp_storage, plain_mode, capsys):
+        """Test backlog list with multiple category filter."""
+        data = {
+            "backlog": [
+                {
+                    "task": "Work task @work",
+                    "categories": ["work"],
+                    "tags": [],
+                    "ts": "2025-05-30T10:00:00"
+                },
+                {
+                    "task": "Personal task @personal",
+                    "categories": ["personal"], 
+                    "tags": [],
+                    "ts": "2025-05-30T11:00:00"
+                },
+                {
+                    "task": "Client task @client",
+                    "categories": ["client"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                }
+            ],
+            "2025-05-30": {"todo": None, "done": []}
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "@work,@personal"
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "Backlog (filtered by: @work, @personal):" in captured.out
+        assert "Work task @work" in captured.out
+        assert "Personal task @personal" in captured.out
+        assert "Client task @client" not in captured.out
+    
+    def test_backlog_list_legacy_format(self, temp_storage, plain_mode, capsys):
+        """Test backlog list filtering with legacy format tasks."""
+        data = {
+            "backlog": [
+                {"task": "Legacy work @work", "ts": "2025-05-30T10:00:00"},
+                {"task": "Legacy personal @personal", "ts": "2025-05-30T11:00:00"}
+            ],
+            "2025-05-30": {"todo": None, "done": []}
+        }
+        temp_storage.write_text(json.dumps(data), encoding='utf-8')
+        
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "@work"
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "Legacy work @work" in captured.out
+        assert "Legacy personal @personal" not in captured.out
+
+
+class TestFilteringEdgeCases:
+    """Test edge cases and error conditions."""
+    
+    def test_empty_backlog_with_filter(self, temp_storage, plain_mode, capsys):
+        """Test filtering empty backlog."""
+        args = MagicMock()
+        args.subcmd = "list"
+        args.filter = "@work"
+        
+        cmd_backlog(args)
+        
+        captured = capsys.readouterr()
+        assert "No backlog items match the filter." in captured.out
+    
+    def test_whitespace_only_filter(self):
+        """Test filter with only whitespace."""
+        is_valid, categories, error = parse_filter_categories("   ")
+        assert is_valid is True
+        assert categories == []
+        assert error == ""
+    
+    def test_comma_only_filter(self):
+        """Test filter with only commas."""
+        is_valid, categories, error = parse_filter_categories(",,,")
+        assert is_valid is True
+        assert categories == []
+        assert error == ""
+    
+    def test_mixed_whitespace_and_commas(self):
+        """Test filter with mixed whitespace and commas."""
+        is_valid, categories, error = parse_filter_categories(" , @work , , @personal , ")
+        assert is_valid is True
+        assert categories == ["work", "personal"]
+        assert error == ""
+    
+    def test_filter_with_at_but_no_name(self):
+        """Test filter with @ but no category name."""
+        is_valid, categories, error = parse_filter_categories("@,@work")
+        assert is_valid is False
+        assert categories == []
+        assert "Invalid category format" in error

--- a/tests/test_filtering_integration.py
+++ b/tests/test_filtering_integration.py
@@ -1,0 +1,512 @@
+"""Integration tests for category filtering via CLI."""
+
+import pytest
+import subprocess
+import json
+import tempfile
+import shutil
+from pathlib import Path
+
+
+class TestCategoryFilteringIntegration:
+    """Test category filtering through the CLI interface."""
+    
+    @pytest.fixture
+    def temp_project_dir(self):
+        """Create a temporary directory with tasker.py for testing."""
+        temp_dir = tempfile.mkdtemp()
+        temp_path = Path(temp_dir)
+        
+        # Copy tasker.py to temp directory
+        original_tasker = Path(__file__).parent.parent / "tasker.py"
+        temp_tasker = temp_path / "tasker.py"
+        shutil.copy2(original_tasker, temp_tasker)
+        
+        # Create temp storage file path
+        temp_storage = temp_path / "test_storage.json"
+        
+        yield temp_path, temp_tasker, temp_storage
+        
+        # Cleanup
+        shutil.rmtree(temp_dir)
+    
+    def run_cli(self, temp_tasker, temp_storage, command, stdin_input=None):
+        """Helper to run CLI commands and return result."""
+        # Handle quoted arguments properly for Windows and spaces
+        if "--filter" in command:
+            # Split command carefully to preserve filter arguments
+            parts = ["python", str(temp_tasker), "--plain", "--store", str(temp_storage)]
+            
+            # Parse the command manually to handle filters with spaces
+            cmd_parts = command.split()
+            i = 0
+            while i < len(cmd_parts):
+                if cmd_parts[i] == "--filter" and i + 1 < len(cmd_parts):
+                    parts.append("--filter")
+                    # Next part is the filter value - remove quotes if present
+                    filter_value = cmd_parts[i + 1]
+                    if filter_value.startswith('"') and filter_value.endswith('"'):
+                        filter_value = filter_value[1:-1]  # Remove quotes
+                    parts.append(filter_value)
+                    i += 2
+                else:
+                    parts.append(cmd_parts[i])
+                    i += 1
+        else:
+            parts = [
+                "python", str(temp_tasker), "--plain", "--store", str(temp_storage)
+            ] + command.split()
+        
+        # Set environment to handle Unicode properly
+        env = {
+            **subprocess.os.environ,
+            'PYTHONIOENCODING': 'utf-8',
+            'PYTHONLEGACYWINDOWSSTDIO': '1'
+        }
+        
+        result = subprocess.run(
+            parts,
+            capture_output=True,
+            text=True,
+            input=stdin_input,
+            timeout=10,
+            env=env
+        )
+        return result
+
+    def load_storage(self, temp_storage):
+        """Helper to load and return storage data."""
+        if temp_storage.exists():
+            return json.loads(temp_storage.read_text(encoding='utf-8'))
+        return {}
+    
+    def setup_test_data(self, temp_storage):
+        """Set up test data with various categories."""
+        data = {
+            "backlog": [
+                {
+                    "task": "Work meeting prep @work",
+                    "categories": ["work"],
+                    "tags": [],
+                    "ts": "2025-05-30T09:00:00"
+                },
+                {
+                    "task": "Personal project @personal",
+                    "categories": ["personal"],
+                    "tags": [],
+                    "ts": "2025-05-30T10:00:00"
+                },
+                {
+                    "task": "Client presentation @client @work #urgent",
+                    "categories": ["client", "work"],
+                    "tags": ["urgent"],
+                    "ts": "2025-05-30T11:00:00"
+                },
+                {
+                    "task": "Groceries @personal",
+                    "categories": ["personal"],
+                    "tags": [],
+                    "ts": "2025-05-30T12:00:00"
+                },
+                {
+                    "task": "No category task",
+                    "categories": [],
+                    "tags": [],
+                    "ts": "2025-05-30T13:00:00"
+                }
+            ],
+            "2025-05-30": {
+                "todo": {
+                    "task": "Active work task @work #important",
+                    "categories": ["work"],
+                    "tags": ["important"],
+                    "ts": "2025-05-30T14:00:00"
+                },
+                "done": [
+                    {
+                        "id": "done1",
+                        "task": {
+                            "task": "Completed work @work",
+                            "categories": ["work"],
+                            "tags": [],
+                            "ts": "2025-05-30T08:00:00"
+                        },
+                        "ts": "2025-05-30T08:30:00"
+                    },
+                    {
+                        "id": "done2",
+                        "task": {
+                            "task": "Completed personal @personal",
+                            "categories": ["personal"],
+                            "tags": [],
+                            "ts": "2025-05-30T07:00:00"
+                        },
+                        "ts": "2025-05-30T07:30:00"
+                    },
+                    {
+                        "id": "done3",
+                        "task": {
+                            "task": "Mixed category done @work @personal",
+                            "categories": ["work", "personal"],
+                            "tags": [],
+                            "ts": "2025-05-30T06:00:00"
+                        },
+                        "ts": "2025-05-30T06:30:00"
+                    }
+                ]
+            }
+        }
+        temp_storage.write_text(json.dumps(data, indent=2), encoding='utf-8')
+
+
+class TestStatusFiltering(TestCategoryFilteringIntegration):
+    """Test status command with filtering."""
+    
+    def test_status_filter_work(self, temp_project_dir):
+        """Test status filtering by work category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work")
+        
+        assert result.returncode == 0
+        assert "(filtered by: @work)" in result.stdout
+        assert "Active work task @work #important" in result.stdout
+        assert "Completed work @work" in result.stdout
+        assert "Mixed category done @work @personal" in result.stdout
+        assert "Completed personal @personal" not in result.stdout
+    
+    def test_status_filter_personal(self, temp_project_dir):
+        """Test status filtering by personal category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @personal")
+        
+        assert result.returncode == 0
+        assert "(filtered by: @personal)" in result.stdout
+        assert "Completed personal @personal" in result.stdout
+        assert "Mixed category done @work @personal" in result.stdout
+        assert "Active work task @work" not in result.stdout
+        assert "No active task matches filter" in result.stdout
+    
+    def test_status_filter_multiple_categories(self, temp_project_dir):
+        """Test status filtering by multiple categories."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work,@personal")
+        
+        assert result.returncode == 0
+        assert "(filtered by: @work, @personal)" in result.stdout
+        assert "Active work task @work" in result.stdout
+        assert "Completed work @work" in result.stdout
+        assert "Completed personal @personal" in result.stdout
+        assert "Mixed category done @work @personal" in result.stdout
+    
+    def test_status_filter_nonexistent_category(self, temp_project_dir):
+        """Test status filtering by nonexistent category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @nonexistent")
+        
+        assert result.returncode == 0
+        assert "(filtered by: @nonexistent)" in result.stdout
+        assert "No active task matches filter" in result.stdout
+        assert "No completed tasks match the filter" in result.stdout
+    
+    def test_status_no_filter(self, temp_project_dir):
+        """Test status without filter shows all tasks."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status")
+        
+        assert result.returncode == 0
+        assert "(filtered by:" not in result.stdout
+        assert "Active work task @work" in result.stdout
+        assert "Completed work @work" in result.stdout
+        assert "Completed personal @personal" in result.stdout
+        assert "Mixed category done @work @personal" in result.stdout
+    
+    def test_status_invalid_filter_format(self, temp_project_dir):
+        """Test status with invalid filter format."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter work")
+        
+        assert result.returncode == 0
+        assert "Categories must start with @" in result.stdout
+        assert "Invalid: 'work'" in result.stdout
+
+
+class TestBacklogFiltering(TestCategoryFilteringIntegration):
+    """Test backlog list command with filtering."""
+    
+    def test_backlog_list_filter_work(self, temp_project_dir):
+        """Test backlog list filtering by work category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work")
+        
+        assert result.returncode == 0
+        assert "Backlog (filtered by: @work):" in result.stdout
+        assert "1. Work meeting prep @work" in result.stdout
+        assert "2. Client presentation @client @work #urgent" in result.stdout
+        assert "Personal project @personal" not in result.stdout
+        assert "Groceries @personal" not in result.stdout
+        assert "No category task" not in result.stdout
+    
+    def test_backlog_list_filter_personal(self, temp_project_dir):
+        """Test backlog list filtering by personal category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @personal")
+        
+        assert result.returncode == 0
+        assert "Backlog (filtered by: @personal):" in result.stdout
+        assert "1. Personal project @personal" in result.stdout
+        assert "2. Groceries @personal" in result.stdout
+        assert "Work meeting prep @work" not in result.stdout
+        assert "Client presentation" not in result.stdout
+    
+    def test_backlog_list_filter_client(self, temp_project_dir):
+        """Test backlog list filtering by client category."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @client")
+        
+        assert result.returncode == 0
+        assert "Backlog (filtered by: @client):" in result.stdout
+        assert "1. Client presentation @client @work #urgent" in result.stdout
+        assert "Work meeting prep" not in result.stdout
+        assert "Personal project" not in result.stdout
+    
+    def test_backlog_list_filter_multiple_categories(self, temp_project_dir):
+        """Test backlog list filtering by multiple categories."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work,@personal")
+        
+        assert result.returncode == 0
+        assert "Backlog (filtered by: @work, @personal):" in result.stdout
+        assert "Work meeting prep @work" in result.stdout
+        assert "Personal project @personal" in result.stdout
+        assert "Client presentation @client @work" in result.stdout
+        assert "Groceries @personal" in result.stdout
+        # Should not show uncategorized task
+        assert "No category task" not in result.stdout
+    
+    def test_backlog_list_no_matches(self, temp_project_dir):
+        """Test backlog list when no items match filter."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @nonexistent")
+        
+        assert result.returncode == 0
+        assert "Backlog (filtered by: @nonexistent):" in result.stdout
+        assert "No backlog items match the filter." in result.stdout
+    
+    def test_backlog_list_no_filter(self, temp_project_dir):
+        """Test backlog list without filter shows all items."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list")
+        
+        assert result.returncode == 0
+        assert "Backlog:" in result.stdout
+        assert "(filtered by:" not in result.stdout
+        assert "Work meeting prep @work" in result.stdout
+        assert "Personal project @personal" in result.stdout
+        assert "Client presentation @client @work" in result.stdout
+        assert "Groceries @personal" in result.stdout
+        assert "No category task" in result.stdout
+    
+    def test_backlog_list_invalid_filter(self, temp_project_dir):
+        """Test backlog list with invalid filter format."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter work,personal")
+        
+        assert result.returncode == 0
+        assert "Categories must start with @" in result.stdout
+        assert "Invalid: 'work'" in result.stdout
+
+
+class TestFilteringWorkflows(TestCategoryFilteringIntegration):
+    """Test complete workflows with filtering."""
+    
+    def test_add_and_filter_workflow(self, temp_project_dir):
+        """Test adding categorized tasks and filtering them."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        # Add work tasks to backlog
+        result = self.run_cli(temp_tasker, temp_storage, "backlog add Work task 1 @work")
+        assert result.returncode == 0
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog add Personal task @personal")
+        assert result.returncode == 0
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog add Mixed task @work @personal")
+        assert result.returncode == 0
+        
+        # Filter by work category
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work")
+        assert result.returncode == 0
+        assert "Work task 1 @work" in result.stdout
+        assert "Mixed task @work @personal" in result.stdout
+        assert "Personal task @personal" not in result.stdout
+        
+        # Filter by personal category
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @personal")
+        assert result.returncode == 0
+        assert "Personal task @personal" in result.stdout
+        assert "Mixed task @work @personal" in result.stdout
+        assert "Work task 1 @work" not in result.stdout
+    
+    def test_complete_and_filter_workflow(self, temp_project_dir):
+        """Test completing categorized tasks and filtering status."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        # Add and activate a work task
+        result = self.run_cli(temp_tasker, temp_storage, "add Work task @work #urgent")
+        assert result.returncode == 0
+        
+        # Complete the task
+        result = self.run_cli(temp_tasker, temp_storage, "done", stdin_input="\n")
+        assert result.returncode == 0
+        
+        # Add a personal task
+        result = self.run_cli(temp_tasker, temp_storage, "add Personal task @personal")
+        assert result.returncode == 0
+        
+        # Complete the personal task
+        result = self.run_cli(temp_tasker, temp_storage, "done", stdin_input="\n")
+        assert result.returncode == 0
+        
+        # Filter status by work
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work")
+        assert result.returncode == 0
+        assert "Work task @work #urgent" in result.stdout
+        assert "Personal task @personal" not in result.stdout
+        
+        # Filter status by personal
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @personal")
+        assert result.returncode == 0
+        assert "Personal task @personal" in result.stdout
+        assert "Work task @work" not in result.stdout
+    
+    def test_case_insensitive_filtering(self, temp_project_dir):
+        """Test that filtering is case insensitive."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        # Add tasks with mixed case categories
+        result = self.run_cli(temp_tasker, temp_storage, "backlog add Task with Work @Work")
+        assert result.returncode == 0
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog add Task with PERSONAL @PERSONAL")
+        assert result.returncode == 0
+        
+        # Filter with lowercase
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work")
+        assert result.returncode == 0
+        assert "Task with Work @Work" in result.stdout
+        
+        # Filter with different case
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @Personal")
+        assert result.returncode == 0
+        assert "Task with PERSONAL @PERSONAL" in result.stdout
+    
+    def test_legacy_format_compatibility(self, temp_project_dir):
+        """Test filtering works with legacy format tasks."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        # Manually create legacy format data
+        legacy_data = {
+            "backlog": [
+                {"task": "Legacy work @work", "ts": "2025-05-30T10:00:00"},
+                {"task": "Legacy personal @personal", "ts": "2025-05-30T11:00:00"}
+            ],
+            "2025-05-30": {
+                "todo": "Legacy active @work",
+                "done": [
+                    {
+                        "id": "legacy1",
+                        "task": "Legacy completed @personal",
+                        "ts": "2025-05-30T09:00:00"
+                    }
+                ]
+            }
+        }
+        temp_storage.write_text(json.dumps(legacy_data, indent=2), encoding='utf-8')
+        
+        # Test backlog filtering
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work")
+        assert result.returncode == 0
+        assert "Legacy work @work" in result.stdout
+        assert "Legacy personal @personal" not in result.stdout
+        
+        # Test status filtering
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work")
+        assert result.returncode == 0
+        assert "Legacy active @work" in result.stdout
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @personal")
+        assert result.returncode == 0
+        assert "Legacy completed @personal" in result.stdout
+        assert "No active task matches filter" in result.stdout
+
+
+class TestFilteringErrorHandling(TestCategoryFilteringIntegration):
+    """Test error handling in filtering."""
+    
+    def test_invalid_category_characters(self, temp_project_dir):
+        """Test filtering with invalid category characters."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        # Test with a simpler invalid format that doesn't cause argument parsing issues
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work!")
+        assert result.returncode == 0
+        assert "Invalid category format" in result.stdout
+    
+    def test_empty_category_name(self, temp_project_dir):
+        """Test filtering with empty category name."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @")
+        assert result.returncode == 0
+        assert "Invalid category format" in result.stdout
+    
+    def test_special_characters_in_filter(self, temp_project_dir):
+        """Test filtering with special characters."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        result = self.run_cli(temp_tasker, temp_storage, "backlog list --filter @work!")
+        assert result.returncode == 0
+        assert "Invalid category format" in result.stdout
+    
+    def test_mixed_valid_invalid_categories(self, temp_project_dir):
+        """Test filtering with mix of valid and invalid categories."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work,invalid")
+        assert result.returncode == 0
+        assert "Categories must start with @" in result.stdout
+        assert "Invalid: 'invalid'" in result.stdout
+    
+    def test_whitespace_handling(self, temp_project_dir):
+        """Test filtering with various whitespace scenarios."""
+        temp_path, temp_tasker, temp_storage = temp_project_dir
+        self.setup_test_data(temp_storage)
+        
+        # Test with simple comma-separated categories (our parse_filter_categories handles internal spaces)
+        result = self.run_cli(temp_tasker, temp_storage, "status --filter @work,@personal")
+        assert result.returncode == 0
+        assert "(filtered by: @work, @personal)" in result.stdout


### PR DESCRIPTION
Add --filter option to filter tasks by categories (@work, @personal, etc.) allowing context-switching knowledge workers to focus on relevant tasks.

Features added:
- Filter status by categories: python tasker.py status --filter @work
- Filter backlog by categories: python tasker.py backlog list --filter @personal
- Multiple category support: --filter @work,@personal (OR logic)
- Invalid category validation with helpful error messages
- Visual filter indicators in output headers
- Backward compatibility with all existing data formats (string, legacy, structured)

Implementation:
- Add parse_filter_categories() for robust filter string parsing
- Add filter_tasks_by_categories() with multi-format task support
- Update cmd_status() and cmd_backlog() with filtering logic
- Extend argument parser with --filter options for status/backlog list
- Comprehensive test coverage (215 tests total, 82 new filtering tests)

Examples:
- 	asker.py status --filter @work - show only work tasks
- 	asker.py backlog list --filter @work,@personal - show work OR personal items
- 	asker.py status --filter invalid - shows helpful error message

Closes Story 2.1: Filter by Category
All acceptance criteria met with comprehensive test coverage.

Fix #21 