### PR TITLE
don't show 'active task' when showing status

### DIFF
--- a/src/momentum/momentum.py
+++ b/src/momentum/momentum.py
@@ -1244,7 +1244,7 @@ def cmd_status(args):
                     if part.startswith("#")
                 ):
                     display_text += f" #{tag}"
-            display_text = f"Active task {display_text.strip()}"
+            display_text = f"{display_text.strip()}"
             formatted_task = format_task_with_tags(
                 display_text, categories, tags, USE_PLAIN
             )


### PR DESCRIPTION
Original:
![image](https://github.com/user-attachments/assets/98ebbb52-e4a2-4849-ac5e-4fc04e9632fe)

New:
![image](https://github.com/user-attachments/assets/7ff57f2b-e90b-47a6-8c0f-653896b5f30b)